### PR TITLE
loosen six requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires='>=2.6,<4',
-    install_requires=['Django>=1.10', 'six==1.12.0'],
+    install_requires=['Django>=1.10', 'six>=1.12.0'],
     extras_require={
         'dev': [
             'flake8>=3.7.7',


### PR DESCRIPTION
the only current usage in https://github.com/BigglesZX/django-admin-thumbnails/blob/9b741fb7bd702ff26b4913c27267cb7776220578/admin_thumbnails/utils.py#L9 should work just fine with newer versions - and not block setups in which other libraries require newer versions