### PR TITLE
Optimise property thumbnail source example to not use count to avoid an extra database query

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ class Person(models.Model):
     # ...
     @property
     def primary_image(self):
-        if self.images.count():
-            return self.images.first().image
+        first_image = self.images.first()
+        if first_image:
+            return first_image.image
         return None
 ```
 


### PR DESCRIPTION
In the readme, there is an example for "Using a property on the model as the thumbnail source" that calls `self.images.count()` followed by `self.images.first()` - this causes the execution of two database queries when you can just call `self.images.first()` and check if there is a return value. This results in faster code since you don't have two DB round trips - and databse lookups for `first()` will be just as quick (if not quicker) than `count()`  This isn't really that relevant to the library (thanks for this library, btw) but I wanted to contribute this correction back so the README reflects best practice.

https://docs.djangoproject.com/en/5.0/topics/db/optimization/#don-t-overuse-contains-count-and-exists